### PR TITLE
This update handles stopping and pausing ORM

### DIFF
--- a/app/server.js
+++ b/app/server.js
@@ -99,7 +99,7 @@ function handleRotationImpulse (dataPoint) {
 }
 
 const rowingEngine = createRowingEngine(config.rowerSettings)
-const rowingStatistics = createRowingStatistics(config)
+const rowingStatistics = createRowingStatistics(config, session)
 rowingEngine.notify(rowingStatistics)
 const workoutRecorder = createWorkoutRecorder()
 
@@ -129,7 +129,6 @@ rowingStatistics.on('sessionTargetReached', (metrics) => {
   webServer.notifyClients(metrics)
   peripheralManager.notifyMetrics('metricsUpdate', metrics)
 })
-
 
 rowingStatistics.on('peripheralMetricsUpdate', (metrics) => {
   peripheralManager.notifyMetrics('metricsUpdate', metrics)

--- a/app/server.js
+++ b/app/server.js
@@ -34,7 +34,7 @@ let movementAllowed = true
 const session = { // a hook for setting session parameters that the rower has to obey
   targetDistance: 0,
   targetTime: 0
-  }
+}
 
 const peripheralManager = createPeripheralManager()
 

--- a/app/server.js
+++ b/app/server.js
@@ -58,7 +58,7 @@ peripheralManager.on('control', (event) => {
     event.res = true
   } else if (event?.req?.name === 'startOrResume') {
     log.debug('startOrResume requested')
-    movementAllowed = true
+    resumeWorkout()
     peripheralManager.notifyStatus({ name: 'startedOrResumedByUser' })
     event.res = true
   } else if (event?.req?.name === 'peripheralMode') {
@@ -72,6 +72,10 @@ peripheralManager.on('control', (event) => {
 function pauseWorkout () {
   movementAllowed = false
   workoutRecorder.handlePause()
+}
+
+function resumeWorkout () {
+  movementAllowed = true
 }
 
 function stopWorkout () {


### PR DESCRIPTION
This update handles stops and pauses from ORM by cutting off the RowingEngine.js from the currentDt-stream. As RowingEngine.js needs to work in absolutes, a free spinning flywheel (that could go on for minutes) wouldn't stop updates to time and distance, even when an end-criterium is reached or the rower has stopped. This change makes stops and pauses more clean.

To generate clean breaks when a certain end-criterium is reached, RowingStatistics.js will check the end-condition for processed impulse. End goal here is to be able to set these end-criteria in the GUI at a later stage. A future improvement would be to use these targets in RowingStatistics as well to let the displayed time or distance count down in the display during rowing (similar to the PM5 does).

Ideally, there will be only one rowing state, and the movementAllowed bit wouldn't be needed. I'm not certain that it would work without this semaphore on the highest level (as I fear there would be timing issues somewhere in stopping a session).